### PR TITLE
bump check-links v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/davidtheclark/remark-lint-no-dead-urls#readme",
   "dependencies": {
-    "check-links": "^1.1.2",
+    "check-links": "^1.1.4",
     "is-online": "^7.0.0",
     "unified-lint-rule": "^1.0.1",
     "unist-util-visit": "^1.1.3"


### PR DESCRIPTION
Fixes some occasional issues where links result in false negatives.