### PR TITLE
ci(travis): update travis matrix to test on node 10 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
   - "lts/*"


### PR DESCRIPTION
eslint 7 dropped support for node 8
https://eslint.org/blog/2020/05/eslint-v7.0.0-released